### PR TITLE
Refactor game

### DIFF
--- a/basic_engine/src/TurnStage.py
+++ b/basic_engine/src/TurnStage.py
@@ -396,7 +396,28 @@ def get_possible_check_optimal(pieces, board, move, player):
 
 
 
-def filter_king_check_optimal_2(board, pieces, moves, player):
+# def filter_king_check_optimal_2(board, pieces, moves, player):
+    
+#     out = []
+    
+#     for _move in moves:
+
+#         #cant these just move outside the loop?
+#         #The problem is apply_move mutates state piece, right?
+#         _board = copy.deepcopy(board)   
+#         _pieces = copy.deepcopy(pieces)
+
+#         board2, pieces2 = apply_move(_move, _board, _pieces, player)
+
+#         b_check = get_possible_check_optimal(pieces2, board2, _move, player)
+        
+#         if not(b_check):
+#             out.append(_move)
+
+#     return out
+
+
+def filter_check_test_copy_opt(board, pieces, moves, player):
     
     out = []
     
@@ -416,28 +437,7 @@ def filter_king_check_optimal_2(board, pieces, moves, player):
 
     return out
 
-
-def filter_king_check_optimal(board, pieces, moves, player):
-    
-    out = []
-    
-    for _move in moves:
-
-        #cant these just move outside the loop?
-        #The problem is apply_move mutates state piece, right?
-        _board = copy.deepcopy(board)   
-        _pieces = copy.deepcopy(pieces)
-
-        board2, pieces2 = apply_move(_move, _board, _pieces, player)
-
-        b_check = get_possible_check_optimal(pieces2, board2, _move, player)
-        
-        if not(b_check):
-            out.append(_move)
-
-    return out
-
-def filter_king_check(board, pieces, moves, player):
+def filter_check_naive(board, pieces, moves, player):
     
     out = []
     
@@ -457,7 +457,7 @@ def filter_king_check(board, pieces, moves, player):
 
     return out
 
-def filter_king_check_test_copy(board, pieces, moves, player):
+def filter_check_test_copy(board, pieces, moves, player):
     
     out = []
     
@@ -472,7 +472,7 @@ def filter_king_check_test_copy(board, pieces, moves, player):
 
     return out
 
-def filter_king_check_test_copy_apply(board, pieces, moves, player):
+def filter_check_test_copy_apply(board, pieces, moves, player):
     
     out = []
     
@@ -590,7 +590,7 @@ class Mutator():
             return pieces
 
 
-def filter_king_check_test_copy_apply_2(board, pieces, moves, player):
+def filter_check_test_copy_apply_2(board, pieces, moves, player):
     
     '''Analyze the computational cost of mutating board instead of
         copying it.'''
@@ -627,7 +627,7 @@ def filter_king_check_test_copy_apply_2(board, pieces, moves, player):
 
     return out
 
-def filter_king_check_test_copy_apply_3(board, pieces, moves, player):
+def filter_check_test_copy_apply_3(board, pieces, moves, player):
     
     '''Analyze the computational cost of mutating board instead of
         copying it.'''
@@ -668,7 +668,7 @@ def filter_king_check_test_copy_apply_3(board, pieces, moves, player):
 
     return out
 
-def filter_king_check_test_copy_apply_4(board, pieces, moves, player):
+def filter_check_opt(board, pieces, moves, player):
     
     '''Rough draft of fully optimized filter_check()'''
 

--- a/basic_engine/src/TurnStage.py
+++ b/basic_engine/src/TurnStage.py
@@ -396,96 +396,8 @@ def get_possible_check_optimal(pieces, board, move, player):
 
 
 
-# def filter_king_check_optimal_2(board, pieces, moves, player):
-    
-#     out = []
-    
-#     for _move in moves:
-
-#         #cant these just move outside the loop?
-#         #The problem is apply_move mutates state piece, right?
-#         _board = copy.deepcopy(board)   
-#         _pieces = copy.deepcopy(pieces)
-
-#         board2, pieces2 = apply_move(_move, _board, _pieces, player)
-
-#         b_check = get_possible_check_optimal(pieces2, board2, _move, player)
-        
-#         if not(b_check):
-#             out.append(_move)
-
-#     return out
 
 
-def filter_check_test_copy_opt(board, pieces, moves, player):
-    
-    out = []
-    
-    for _move in moves:
-
-        #cant these just move outside the loop?
-        #The problem is apply_move mutates state piece, right?
-        _board = copy.deepcopy(board)   
-        _pieces = copy.deepcopy(pieces)
-
-        board2, pieces2 = apply_move(_move, _board, _pieces, player)
-
-        b_check = get_possible_check_optimal(pieces2, board2, _move, player)
-        
-        if not(b_check):
-            out.append(_move)
-
-    return out
-
-def filter_check_naive(board, pieces, moves, player):
-    
-    out = []
-    
-    for _move in moves:
-
-        _board = copy.deepcopy(board)   # .copy?
-        _pieces = copy.deepcopy(pieces)
-
-        board2, pieces2 = apply_move(_move, _board, _pieces, player)
-
-        player2 = not(player)
-
-        b_check = get_possible_check(pieces2, board2, player2)
-        
-        if not(b_check):
-            out.append(_move)
-
-    return out
-
-def filter_check_test_copy(board, pieces, moves, player):
-    
-    out = []
-    
-    for _move in moves:
-
-        _board = copy.deepcopy(board)   # .copy?
-        _pieces = copy.deepcopy(pieces)
-
-        #board2, pieces2 = apply_move(_move, _board, _pieces, player)    
-
-        out.append(_move)
-
-    return out
-
-def filter_check_test_copy_apply(board, pieces, moves, player):
-    
-    out = []
-    
-    for _move in moves:
-
-        _board = copy.deepcopy(board)   # .copy?
-        _pieces = copy.deepcopy(pieces)
-
-        board2, pieces2 = apply_move(_move, _board, _pieces, player)    
-
-        out.append(_move)
-
-    return out
 
 class Mutator():
     
@@ -590,6 +502,91 @@ class Mutator():
             return pieces
 
 
+def filter_check_naive(board, pieces, moves, player):
+    
+    out = []
+    
+    for _move in moves:
+
+        _board = copy.deepcopy(board)   # .copy?
+        _pieces = copy.deepcopy(pieces)
+
+        board2, pieces2 = apply_move(_move, _board, _pieces, player)
+
+        player2 = not(player)
+
+        b_check = get_possible_check(pieces2, board2, player2)
+        
+        if not(b_check):
+            out.append(_move)
+
+    return out
+
+
+def filter_check_opt(board, pieces, moves, player):
+    
+    '''Rough draft of fully optimized filter_check()'''
+
+    out = []
+
+    mutator = Mutator()
+    
+    for _move in moves:
+
+        b_regular =  (_move.code == MOVE_CODE['regular'])
+
+        if b_regular:
+            _board = mutator.mutate_board(board, _move)
+            _pieces = mutator.mutate_pieces(pieces, player)
+        else:
+            #Non-Standard Board/Piece Mutation
+            _board = copy.deepcopy(board)
+            _pieces = copy.deepcopy(pieces)
+            _board, _pieces = apply_move(_move, _board, _pieces, player)
+
+        b_check = get_possible_check_optimal(_pieces, _board, _move, player)
+        
+        if not(b_check):
+            out.append(_move)
+
+        if b_regular:
+            board = mutator.demutate_board(_board)
+            pieces = mutator.demutate_pieces(_pieces, player)
+
+    return out
+
+
+def filter_check_test_copy(board, pieces, moves, player):
+    
+    out = []
+    
+    for _move in moves:
+
+        _board = copy.deepcopy(board)   # .copy?
+        _pieces = copy.deepcopy(pieces)
+
+        #board2, pieces2 = apply_move(_move, _board, _pieces, player)    
+
+        out.append(_move)
+
+    return out
+
+def filter_check_test_copy_apply(board, pieces, moves, player):
+    
+    out = []
+    
+    for _move in moves:
+
+        _board = copy.deepcopy(board)   # .copy?
+        _pieces = copy.deepcopy(pieces)
+
+        board2, pieces2 = apply_move(_move, _board, _pieces, player)    
+
+        out.append(_move)
+
+    return out
+
+
 def filter_check_test_copy_apply_2(board, pieces, moves, player):
     
     '''Analyze the computational cost of mutating board instead of
@@ -626,6 +623,7 @@ def filter_check_test_copy_apply_2(board, pieces, moves, player):
         out.append(_move)
 
     return out
+
 
 def filter_check_test_copy_apply_3(board, pieces, moves, player):
     
@@ -668,37 +666,27 @@ def filter_check_test_copy_apply_3(board, pieces, moves, player):
 
     return out
 
-def filter_check_opt(board, pieces, moves, player):
+
+def filter_check_test_copy_opt(board, pieces, moves, player):
     
-    '''Rough draft of fully optimized filter_check()'''
-
     out = []
-
-    mutator = Mutator()
     
     for _move in moves:
 
-        b_regular =  (_move.code == MOVE_CODE['regular'])
+        #cant these just move outside the loop?
+        #The problem is apply_move mutates state piece, right?
+        _board = copy.deepcopy(board)   
+        _pieces = copy.deepcopy(pieces)
 
-        if b_regular:
-            _board = mutator.mutate_board(board, _move)
-            _pieces = mutator.mutate_pieces(pieces, player)
-        else:
-            #Non-Standard Board/Piece Mutation
-            _board = copy.deepcopy(board)
-            _pieces = copy.deepcopy(pieces)
-            _board, _pieces = apply_move(_move, _board, _pieces, player)
+        board2, pieces2 = apply_move(_move, _board, _pieces, player)
 
-        b_check = get_possible_check_optimal(_pieces, _board, _move, player)
+        b_check = get_possible_check_optimal(pieces2, board2, _move, player)
         
         if not(b_check):
             out.append(_move)
 
-        if b_regular:
-            board = mutator.demutate_board(_board)
-            pieces = mutator.demutate_pieces(_pieces, player)
-
     return out
+
 
 def is_king_in_check(board, pieces, player):
 

--- a/basic_engine/src/TurnStage.py
+++ b/basic_engine/src/TurnStage.py
@@ -396,9 +396,6 @@ def get_possible_check_optimal(pieces, board, move, player):
 
 
 
-
-
-
 class Mutator():
     
     '''Helper Class for preserving board state without deepcopying.'''
@@ -503,6 +500,10 @@ class Mutator():
 
 
 def filter_check_naive(board, pieces, moves, player):
+
+    ''' Naive method to see remove any individual _move
+        that would put current player in check. Runs in
+        N^2 time, where N = num_available_moves.'''
     
     out = []
     
@@ -525,7 +526,9 @@ def filter_check_naive(board, pieces, moves, player):
 
 def filter_check_opt(board, pieces, moves, player):
     
-    '''Rough draft of fully optimized filter_check()'''
+    ''' Fully optimized filter_check(). Uses Mutator and 
+        get_possible_check_optimal to run in ~3.5N time instead of N^2,
+        where N = num_available_moves, and is typically between 18-30.'''
 
     out = []
 
@@ -558,6 +561,11 @@ def filter_check_opt(board, pieces, moves, player):
 
 def filter_check_test_copy(board, pieces, moves, player):
     
+    ''' A perf-test function: to analyze the computational cost of 
+        deepcopying board, pieces. It does not call apply_move or
+        get_possible_check. Use this to figure out how much just copying
+        costs in computation out of the whole required function. '''
+
     out = []
     
     for _move in moves:
@@ -572,6 +580,11 @@ def filter_check_test_copy(board, pieces, moves, player):
     return out
 
 def filter_check_test_copy_apply(board, pieces, moves, player):
+
+    ''' A perf-test function: to analyze the computational cost of 
+        deepcopying board, pieces and running apply_move(). The only thing
+        it doesn't do is call get_possible_check allowing us to interpret 
+        the difference between this and filter_check_naive. '''
     
     out = []
     
@@ -589,8 +602,9 @@ def filter_check_test_copy_apply(board, pieces, moves, player):
 
 def filter_check_test_copy_apply_2(board, pieces, moves, player):
     
-    '''Analyze the computational cost of mutating board instead of
-        copying it.'''
+    ''' A perf-test function: to analyze the computational cost of 
+        mutating board instead of deepcopying it. Does not call any
+        get_possible_check function.'''
     
     #We'll need to set this as the default and run pytest to see if
     # it's working
@@ -627,8 +641,9 @@ def filter_check_test_copy_apply_2(board, pieces, moves, player):
 
 def filter_check_test_copy_apply_3(board, pieces, moves, player):
     
-    '''Analyze the computational cost of mutating board instead of
-        copying it.'''
+    ''' A perf-test function: to analyze the computational cost of 
+        mutating board and pieces instead of deepcopying them. Does not
+        call any get_possible_check function.'''
     
     #We'll need to set this as the default and run pytest to see if
     # it's working
@@ -668,6 +683,9 @@ def filter_check_test_copy_apply_3(board, pieces, moves, player):
 
 
 def filter_check_test_copy_opt(board, pieces, moves, player):
+    
+    ''' A perf-test function: uses deepcopy instead of mutator, but does
+        use possible_check_optimal, so it's faster than naive.'''
     
     out = []
     

--- a/basic_engine/src/main.py
+++ b/basic_engine/src/main.py
@@ -30,6 +30,7 @@ class Game():
         ,pgn_control = ()
         ,s_instructions = ""
         ,s_pgn_instructions = ""
+        ,b_initialize = True
         ,init_board = None
         ,init_player = None
         ,init_pieces = None
@@ -63,6 +64,7 @@ class Game():
 
         self.outcome = None
 
+        self.init_switch = b_initialize
         self.init_player = init_player
         self.init_board = copy.deepcopy(init_board)
         self.init_pieces = copy.deepcopy(init_pieces)
@@ -85,6 +87,9 @@ class Game():
 
     def reset_test(self):
         self.b_test_exit = False
+
+    def reset_init_switch(self):
+        self.init_switch = True
 
     def check_test_exit_moves(self, **kwargs):
         '''bool: exit after 'moves' is calcd / before check_enggame() in play().'''
@@ -119,22 +124,48 @@ class Game():
         return move
 
 
+    def initialize(self):
+        ''' '''
+        _board = Board()
+        
+        #Set board and pieces
+        if self.init_board is not None:
+            # init_board represent data_by_player
+            _board.set_data(self.init_board)     
+            _pieces = self.init_pieces
+        else:
+            _board, _pieces = place_pieces(_board)
+        
+        # Set player and i_turn
+        # These incremetent at top-of-turn-loop; 
+        # so they're off by one right now.
+        
+        #TODO - make i_turn local and overideable
+        self.i_turn = 0
+
+        _player = False 
+        if self.init_player is not None:
+            _player = not(self.init_player)        
+        
+        self.init_switch = False
+
+        return _board, _pieces, _player
+
+
+    def load(self):
+        ''' load relevant state from Game into play '''
+        pass
+
+
+    def save(self):
+        ''' save relevant state from play into Game '''
+        pass
+        
 
     def play(self, **kwargs):
 
-        board = Board()
-        
-        if self.init_board is not None:
-            board.set_data(self.init_board)     #init_board represent data_by_player
-            pieces = self.init_pieces
-        else:
-            board, pieces = place_pieces(board)
-        
-        #These incremetent at top-of-turn-loop
-        self.i_turn = 0
-        player = False 
-        if self.init_player is not None:
-            player = not(self.init_player)
+        if self.init_switch:
+            board, pieces, player = self.initialize()
 
         game_going = True
         
@@ -654,6 +685,7 @@ def test_filter_forward_diagonal_1():
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
+    game.reset_init_switch()
     ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
                                 ,king_in_check_on = False
                                 )
@@ -691,6 +723,7 @@ def test_filter_forward_diagonal_1():
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
+    game.reset_init_switch()
     ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
                                 ,king_in_check_on = False
                                 )
@@ -737,6 +770,7 @@ def test_filter_forward_diagonal_2():
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
+    game.reset_init_switch()
     ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
                                 ,king_in_check_on = False
                                 )
@@ -774,6 +808,7 @@ def test_filter_forward_diagonal_2():
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
+    game.reset_init_switch()
     ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
                                 ,king_in_check_on = False
                                 )
@@ -816,6 +851,7 @@ def test_pawn_check_true_positive_1():
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
+    game.reset_init_switch()
     ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
                                 ,king_in_check_on = False
                                 )
@@ -858,6 +894,7 @@ def test_pawn_check_true_positive_1():
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
+    game.reset_init_switch()
     ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
                                 ,king_in_check_on = False
                                 )
@@ -904,6 +941,7 @@ def test_pawn_check_negative_1():
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
+    game.reset_init_switch()
     ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
                                 ,king_in_check_on = False
                                 )
@@ -945,6 +983,7 @@ def test_pawn_check_negative_1():
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
+    game.reset_init_switch()
     ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
                                 ,king_in_check_on = False
                                 )

--- a/basic_engine/src/main.py
+++ b/basic_engine/src/main.py
@@ -183,20 +183,24 @@ class Game():
 
             if kwargs.get('filter_check_naive', False):
                 moves = filter_king_check(board, pieces, moves, player)
-            if kwargs.get('king_in_check_test_copy', False):
-                moves = filter_king_check_test_copy(board, pieces, moves, player)
-            if kwargs.get('king_in_check_test_copy_apply', False):
-                moves = filter_king_check_test_copy_apply(board, pieces, moves, player)
-            if kwargs.get('king_in_check_test_copy_apply_2', False):
-                moves = filter_king_check_test_copy_apply_2(board, pieces, moves, player)
-            if kwargs.get('king_in_check_test_copy_apply_3', False):
-                moves = filter_king_check_test_copy_apply_3(board, pieces, moves, player)
             if kwargs.get('filter_check_opt', True):
                 moves = filter_king_check_test_copy_apply_4(board, pieces, moves, player)
-            if kwargs.get('king_in_check_optimal', False):
+
+            if kwargs.get('filter_check_test_copy', False):
+                moves = filter_king_check_test_copy(board, pieces, moves, player)
+            if kwargs.get('filter_check_test_copy_apply', False):
+                moves = filter_king_check_test_copy_apply(board, pieces, moves, player)
+            if kwargs.get('filter_check_test_copy_apply_2', False):
+                moves = filter_king_check_test_copy_apply_2(board, pieces, moves, player)
+            if kwargs.get('filter_check_test_copy_apply_3', False):
+                moves = filter_king_check_test_copy_apply_3(board, pieces, moves, player)
+            if kwargs.get('filter_check_test_copy_opt', False):
                 moves = filter_king_check_optimal(board, pieces, moves, player)
-            if kwargs.get('king_in_check_optimal_2', False):
-                moves = filter_king_check_optimal_2(board, pieces, moves, player)
+            
+
+
+    
+    
             
             self.display.print_turn(pieces, player)
 

--- a/basic_engine/src/main.py
+++ b/basic_engine/src/main.py
@@ -181,7 +181,7 @@ class Game():
 
             moves = get_available_moves(pieces, board, player)
 
-            if kwargs.get('king_in_check_on', False):
+            if kwargs.get('filter_check_naive', False):
                 moves = filter_king_check(board, pieces, moves, player)
             if kwargs.get('king_in_check_test_copy', False):
                 moves = filter_king_check_test_copy(board, pieces, moves, player)
@@ -191,7 +191,7 @@ class Game():
                 moves = filter_king_check_test_copy_apply_2(board, pieces, moves, player)
             if kwargs.get('king_in_check_test_copy_apply_3', False):
                 moves = filter_king_check_test_copy_apply_3(board, pieces, moves, player)
-            if kwargs.get('king_in_check_test_copy_apply_4', True):
+            if kwargs.get('filter_check_opt', True):
                 moves = filter_king_check_test_copy_apply_4(board, pieces, moves, player)
             if kwargs.get('king_in_check_optimal', False):
                 moves = filter_king_check_optimal(board, pieces, moves, player)
@@ -574,8 +574,8 @@ def test_filter_check_pawn_1():
                 ,init_player = False     
                 ,test_exit_moves = 1    
                 )
-    ret_data2a = game2a.play(king_in_check_test_copy_apply_4 = False
-                            ,king_in_check_on = True
+    ret_data2a = game2a.play(filter_check_opt = False
+                            ,filter_check_naive = True
                             )
     generic_check_moves = ret_data2a['moves']
 
@@ -585,8 +585,8 @@ def test_filter_check_pawn_1():
                 ,init_player = False     
                 ,test_exit_moves = 1    
                 )
-    ret_data2b = game2b.play(king_in_check_test_copy_apply_4 = True
-                            ,king_in_check_on = False
+    ret_data2b = game2b.play(filter_check_opt = True
+                            ,filter_check_naive = False
                             )
     opt_check_moves = ret_data2b['moves']
 
@@ -629,8 +629,8 @@ H  ~ ~ ~ ~ ~ ~ ~ ~
                 ,init_player = False     
                 ,test_exit_moves = 1    
                 )
-    ret_data2a = game2a.play(king_in_check_test_copy_apply_4 = False
-                            ,king_in_check_on = True
+    ret_data2a = game2a.play(filter_check_opt = False
+                            ,filter_check_naive = True
                             )
     generic_check_moves = ret_data2a['moves']
 
@@ -639,8 +639,8 @@ H  ~ ~ ~ ~ ~ ~ ~ ~
                 ,init_player = False     
                 ,test_exit_moves = 1    
                 )
-    ret_data2b = game2b.play(king_in_check_test_copy_apply_4 = True
-                            ,king_in_check_on = False
+    ret_data2b = game2b.play(filter_check_opt = True
+                            ,filter_check_naive = False
                             )
     opt_check_moves = ret_data2b['moves']
     
@@ -679,15 +679,15 @@ def test_filter_forward_diagonal_1():
                 ,test_exit_moves = 1    
                 )
 
-    ret_data_generic = game.play(king_in_check_test_copy_apply_4 = False
-                                ,king_in_check_on = True
+    ret_data_generic = game.play(filter_check_opt = False
+                                ,filter_check_naive = True
                                 )
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
     game.reset_init_switch()
-    ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
-                                ,king_in_check_on = False
+    ret_data_opt = game.play(filter_check_opt = True
+                                ,filter_check_naive = False
                                 )
     opt_check_moves = ret_data_opt['moves']
 
@@ -717,15 +717,15 @@ def test_filter_forward_diagonal_1():
                 ,test_exit_moves = 1    
                 )
 
-    ret_data_generic = game.play(king_in_check_test_copy_apply_4 = False
-                                ,king_in_check_on = True
+    ret_data_generic = game.play(filter_check_opt = False
+                                ,filter_check_naive = True
                                 )
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
     game.reset_init_switch()
-    ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
-                                ,king_in_check_on = False
+    ret_data_opt = game.play(filter_check_opt = True
+                                ,filter_check_naive = False
                                 )
     opt_check_moves = ret_data_opt['moves']
 
@@ -764,15 +764,15 @@ def test_filter_forward_diagonal_2():
                 ,test_exit_moves = 1    
                 )
 
-    ret_data_generic = game.play(king_in_check_test_copy_apply_4 = False
-                                ,king_in_check_on = True
+    ret_data_generic = game.play(filter_check_opt = False
+                                ,filter_check_naive = True
                                 )
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
     game.reset_init_switch()
-    ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
-                                ,king_in_check_on = False
+    ret_data_opt = game.play(filter_check_opt = True
+                                ,filter_check_naive = False
                                 )
     opt_check_moves = ret_data_opt['moves']
 
@@ -802,15 +802,15 @@ def test_filter_forward_diagonal_2():
                 ,test_exit_moves = 1    
                 )
 
-    ret_data_generic = game.play(king_in_check_test_copy_apply_4 = False
-                                ,king_in_check_on = True
+    ret_data_generic = game.play(filter_check_opt = False
+                                ,filter_check_naive = True
                                 )
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
     game.reset_init_switch()
-    ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
-                                ,king_in_check_on = False
+    ret_data_opt = game.play(filter_check_opt = True
+                                ,filter_check_naive = False
                                 )
     opt_check_moves = ret_data_opt['moves']
 
@@ -845,15 +845,15 @@ def test_pawn_check_true_positive_1():
                 ,test_exit_moves = 1    
                 )
 
-    ret_data_generic = game.play(king_in_check_test_copy_apply_4 = False
-                                ,king_in_check_on = True
+    ret_data_generic = game.play(filter_check_opt = False
+                                ,filter_check_naive = True
                                 )
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
     game.reset_init_switch()
-    ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
-                                ,king_in_check_on = False
+    ret_data_opt = game.play(filter_check_opt = True
+                                ,filter_check_naive = False
                                 )
     opt_check_moves = ret_data_opt['moves']
 
@@ -888,15 +888,15 @@ def test_pawn_check_true_positive_1():
                 ,test_exit_moves = 1    
                 )
 
-    ret_data_generic = game.play(king_in_check_test_copy_apply_4 = False
-                                ,king_in_check_on = True
+    ret_data_generic = game.play(filter_check_opt = False
+                                ,filter_check_naive = True
                                 )
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
     game.reset_init_switch()
-    ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
-                                ,king_in_check_on = False
+    ret_data_opt = game.play(filter_check_opt = True
+                                ,filter_check_naive = False
                                 )
     opt_check_moves = ret_data_opt['moves']
 
@@ -935,15 +935,15 @@ def test_pawn_check_negative_1():
                 ,test_exit_moves = 1    
                 )
 
-    ret_data_generic = game.play(king_in_check_test_copy_apply_4 = False
-                                ,king_in_check_on = True
+    ret_data_generic = game.play(filter_check_opt = False
+                                ,filter_check_naive = True
                                 )
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
     game.reset_init_switch()
-    ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
-                                ,king_in_check_on = False
+    ret_data_opt = game.play(filter_check_opt = True
+                                ,filter_check_naive = False
                                 )
     opt_check_moves = ret_data_opt['moves']
 
@@ -977,15 +977,15 @@ def test_pawn_check_negative_1():
                 ,test_exit_moves = 1    
                 )
 
-    ret_data_generic = game.play(king_in_check_test_copy_apply_4 = False
-                                ,king_in_check_on = True
+    ret_data_generic = game.play(filter_check_opt = False
+                                ,filter_check_naive = True
                                 )
     generic_check_moves = ret_data_generic['moves']
 
     game.reset_test()
     game.reset_init_switch()
-    ret_data_opt = game.play(king_in_check_test_copy_apply_4 = True
-                                ,king_in_check_on = False
+    ret_data_opt = game.play(filter_check_opt = True
+                                ,filter_check_naive = False
                                 )
     opt_check_moves = ret_data_opt['moves']
 
@@ -1333,8 +1333,8 @@ def batchtest_multi_pgn_games_1(**kwargs):
         try:
             game = Game(s_pgn_instructions = s_game)
             if b_naive_check:
-                ret = game.play(king_in_check_on = True
-                                ,king_in_check_test_copy_apply_4 = False)
+                ret = game.play(filter_check_naive = True
+                                ,filter_check_opt = False)
             else:
                 ret = game.play()
         except Exception as e:
@@ -1393,8 +1393,8 @@ def test_filter_check_pinned_piece_1():
                 ,test_exit_moves = 1    
                 )
 
-    # ret = game.play(king_in_check_on=True)
-    ret = game.play(king_in_check_on=False)
+    # ret = game.play(filter_check_naive=True)
+    ret = game.play(filter_check_naive=False)
     moves = ret['moves']
 
     assert not(Move(pos0=(5, 2), pos1=(6, 4), code=0) in moves)

--- a/basic_engine/src/main.py
+++ b/basic_engine/src/main.py
@@ -9,15 +9,17 @@ from GameLog import GameSchema
 from Display import Display
 from TurnStage import increment_turn, get_available_moves, apply_move
 from TurnStage import check_endgame
-from TurnStage import filter_king_check
 from TurnStage import is_king_in_check
-from TurnStage import filter_king_check_test_copy   #temp
-from TurnStage import filter_king_check_test_copy_apply   #temp
-from TurnStage import filter_king_check_optimal   #emp
-from TurnStage import filter_king_check_optimal_2   #temp
-from TurnStage import filter_king_check_test_copy_apply_2   #temp
-from TurnStage import filter_king_check_test_copy_apply_3   #temp
-from TurnStage import filter_king_check_test_copy_apply_4   #temp
+from TurnStage import filter_check_naive
+from TurnStage import filter_check_opt   
+
+from TurnStage import filter_check_test_copy   
+from TurnStage import filter_check_test_copy_apply   
+from TurnStage import filter_check_test_copy_apply_2
+from TurnStage import filter_check_test_copy_apply_3
+from TurnStage import filter_check_test_copy_opt
+
+
 
 Move = moveHolder()
 
@@ -182,25 +184,21 @@ class Game():
             moves = get_available_moves(pieces, board, player)
 
             if kwargs.get('filter_check_naive', False):
-                moves = filter_king_check(board, pieces, moves, player)
+                moves = filter_check_naive(board, pieces, moves, player)
             if kwargs.get('filter_check_opt', True):
-                moves = filter_king_check_test_copy_apply_4(board, pieces, moves, player)
+                moves = filter_check_opt(board, pieces, moves, player)
 
             if kwargs.get('filter_check_test_copy', False):
-                moves = filter_king_check_test_copy(board, pieces, moves, player)
+                moves = filter_check_test_copy(board, pieces, moves, player)
             if kwargs.get('filter_check_test_copy_apply', False):
-                moves = filter_king_check_test_copy_apply(board, pieces, moves, player)
+                moves = filter_check_test_copy_apply(board, pieces, moves, player)
             if kwargs.get('filter_check_test_copy_apply_2', False):
-                moves = filter_king_check_test_copy_apply_2(board, pieces, moves, player)
+                moves = filter_check_test_copy_apply_2(board, pieces, moves, player)
             if kwargs.get('filter_check_test_copy_apply_3', False):
-                moves = filter_king_check_test_copy_apply_3(board, pieces, moves, player)
+                moves = filter_check_test_copy_apply_3(board, pieces, moves, player)
             if kwargs.get('filter_check_test_copy_opt', False):
-                moves = filter_king_check_optimal(board, pieces, moves, player)
+                moves = filter_check_test_copy_opt(board, pieces, moves, player)
             
-
-
-    
-    
             
             self.display.print_turn(pieces, player)
 

--- a/basic_engine/tests/batchverify.py
+++ b/basic_engine/tests/batchverify.py
@@ -211,7 +211,7 @@ def verify_check_schedule_match(data, b_naive_check=False, b_assert=True
                     ,b_log_check_schedule=True
                     )
 
-        game.play( king_in_check_on = b_naive_check
+        game.play( filter_check_naive = b_naive_check
                     ,king_in_check_test_copy_apply_4 = not(b_naive_check)
                     )
 
@@ -264,7 +264,7 @@ def verify_check_schedule_match(data, b_naive_check=False, b_assert=True
                         game_replay = Game(s_pgn_instructions = s_pgn
                                             ,test_exit_moves = _i_turn + 2)
                         
-                        ret = game_replay.play( king_in_check_on = b_naive_check
+                        ret = game_replay.play( filter_check_naive = b_naive_check
                                         ,king_in_check_test_copy_apply_4 = not(b_naive_check)
                                         )
 
@@ -337,7 +337,7 @@ def verify_move_available(data
             b_pass = True
             game = Game(s_pgn_instructions=s_pgn)
 
-            ret = game.play( king_in_check_on = b_naive_check
+            ret = game.play( filter_check_naive = b_naive_check
                         ,king_in_check_test_copy_apply_4 = not(b_naive_check)
                         )
         

--- a/basic_engine/tests/batchverify.py
+++ b/basic_engine/tests/batchverify.py
@@ -212,7 +212,7 @@ def verify_check_schedule_match(data, b_naive_check=False, b_assert=True
                     )
 
         game.play( filter_check_naive = b_naive_check
-                    ,king_in_check_test_copy_apply_4 = not(b_naive_check)
+                    ,filter_check_opt = not(b_naive_check)
                     )
 
         log_check_schedule = game.get_gamelog().get_log_check_schedule()
@@ -265,7 +265,7 @@ def verify_check_schedule_match(data, b_naive_check=False, b_assert=True
                                             ,test_exit_moves = _i_turn + 2)
                         
                         ret = game_replay.play( filter_check_naive = b_naive_check
-                                        ,king_in_check_test_copy_apply_4 = not(b_naive_check)
+                                        ,filter_check_opt = not(b_naive_check)
                                         )
 
                         replay_pieces = ret['pieces']
@@ -338,7 +338,7 @@ def verify_move_available(data
             game = Game(s_pgn_instructions=s_pgn)
 
             ret = game.play( filter_check_naive = b_naive_check
-                        ,king_in_check_test_copy_apply_4 = not(b_naive_check)
+                        ,filter_check_opt = not(b_naive_check)
                         )
         
             #if return code is plain int then its incompatible at that move

--- a/basic_engine/tools/perf_test.py
+++ b/basic_engine/tools/perf_test.py
@@ -22,7 +22,7 @@ def select_function(s_function):
     if s_function == "baseline":
         
         game = Game(s_instructions = ss)
-        game.play(king_in_check_on=False)    
+        game.play(filter_check_naive=False)    
         
     if s_function == "naive_check":
 
@@ -32,27 +32,27 @@ def select_function(s_function):
     if s_function == "test_copy":
         
         game = Game(s_instructions = ss)
-        game.play(king_in_check_on=False, king_in_check_test_copy=True)
+        game.play(filter_check_naive=False, king_in_check_test_copy=True)
 
     if s_function == "test_copy_apply":
         
         game = Game(s_instructions = ss)
-        game.play(king_in_check_on=False, king_in_check_test_copy_apply=True)
+        game.play(filter_check_naive=False, king_in_check_test_copy_apply=True)
 
     if s_function == "test_c_apply_2":
             
         game = Game(s_instructions = ss)
-        game.play(king_in_check_on=False, king_in_check_test_copy_apply_2=True)
+        game.play(filter_check_naive=False, king_in_check_test_copy_apply_2=True)
 
     if s_function == "test_c_apply_3":
             
         game = Game(s_instructions = ss)
-        game.play(king_in_check_on=False, king_in_check_test_copy_apply_3=True)
+        game.play(filter_check_naive=False, king_in_check_test_copy_apply_3=True)
 
     if s_function == "test_c_apply_4":
             
         game = Game(s_instructions = ss)
-        game.play(king_in_check_on=False, king_in_check_test_copy_apply_4=True)
+        game.play(filter_check_naive=False, king_in_check_test_copy_apply_4=True)
     
     if s_function == "baseline_tt":
         
@@ -60,7 +60,7 @@ def select_function(s_function):
                     ,b_log_turn_time = True
                     ,b_log_num_available = True 
                     )  
-        game.play(king_in_check_on=False)    
+        game.play(filter_check_naive=False)    
         return game.get_gamelog()
     
     if s_function == "naive_check_tt":
@@ -69,7 +69,7 @@ def select_function(s_function):
             ,b_log_turn_time = True
             ,b_log_num_available = True 
             )  
-        game.play(king_in_check_on=True)    
+        game.play(filter_check_naive=True)    
         return game.get_gamelog()
 
     if s_function == "baseline_long":
@@ -78,7 +78,7 @@ def select_function(s_function):
                     ,b_log_turn_time = True
                     ,b_log_num_available = True 
                     )  
-        game.play(king_in_check_on=False)    
+        game.play(filter_check_naive=False)    
         return game.get_gamelog()
     
     if s_function == "naive_long":
@@ -87,7 +87,7 @@ def select_function(s_function):
             ,b_log_turn_time = True
             ,b_log_num_available = True 
             )  
-        game.play(king_in_check_on=True)    
+        game.play(filter_check_naive=True)    
         return game.get_gamelog()
 
     if s_function == "optimal1_long":
@@ -96,7 +96,7 @@ def select_function(s_function):
                     ,b_log_turn_time = True
                     ,b_log_num_available = True 
                     )  
-        game.play(king_in_check_on=False, king_in_check_optimal = True)    
+        game.play(filter_check_naive=False, king_in_check_optimal = True)    
         return game.get_gamelog()
     
     if s_function == "optimal2_long":
@@ -105,18 +105,18 @@ def select_function(s_function):
             ,b_log_turn_time = True
             ,b_log_num_available = True 
             )  
-        game.play(king_in_check_on=False, king_in_check_optimal_2 = True)    
+        game.play(filter_check_naive=False, king_in_check_optimal_2 = True)    
         return game.get_gamelog()
 
     if s_function == "check_optimal":
             
         game = Game(s_instructions = ss)
-        game.play(king_in_check_on=False, king_in_check_optimal=True)
+        game.play(filter_check_naive=False, king_in_check_optimal=True)
 
     if s_function == "check_optimal_2":
             
         game = Game(s_instructions = ss)
-        game.play(king_in_check_on=False, king_in_check_optimal_2=True)
+        game.play(filter_check_naive=False, king_in_check_optimal_2=True)
 
     return None     #to show that the function is no returning a test exit data
 

--- a/basic_engine/tools/perf_test.py
+++ b/basic_engine/tools/perf_test.py
@@ -32,22 +32,22 @@ def select_function(s_function):
     if s_function == "test_copy":
         
         game = Game(s_instructions = ss)
-        game.play(filter_check_naive=False, king_in_check_test_copy=True)
+        game.play(filter_check_naive=False, filter_check_test_copy=True)
 
     if s_function == "test_copy_apply":
         
         game = Game(s_instructions = ss)
-        game.play(filter_check_naive=False, king_in_check_test_copy_apply=True)
+        game.play(filter_check_naive=False, filter_check_test_copy_apply=True)
 
     if s_function == "test_c_apply_2":
             
         game = Game(s_instructions = ss)
-        game.play(filter_check_naive=False, king_in_check_test_copy_apply_2=True)
+        game.play(filter_check_naive=False, filter_check_test_copy_apply_2=True)
 
     if s_function == "test_c_apply_3":
             
         game = Game(s_instructions = ss)
-        game.play(filter_check_naive=False, king_in_check_test_copy_apply_3=True)
+        game.play(filter_check_naive=False, filter_check_test_copy_apply_3=True)
 
     if s_function == "test_c_apply_4":
             
@@ -105,7 +105,7 @@ def select_function(s_function):
             ,b_log_turn_time = True
             ,b_log_num_available = True 
             )  
-        game.play(filter_check_naive=False, king_in_check_optimal_2 = True)    
+        game.play(filter_check_naive=False, filter_check_test_copy_opt = True)    
         return game.get_gamelog()
 
     if s_function == "check_optimal":
@@ -116,7 +116,7 @@ def select_function(s_function):
     if s_function == "check_optimal_2":
             
         game = Game(s_instructions = ss)
-        game.play(filter_check_naive=False, king_in_check_optimal_2=True)
+        game.play(filter_check_naive=False, filter_check_test_copy_opt=True)
 
     return None     #to show that the function is no returning a test exit data
 

--- a/basic_engine/tools/perf_test.py
+++ b/basic_engine/tools/perf_test.py
@@ -52,7 +52,7 @@ def select_function(s_function):
     if s_function == "test_c_apply_4":
             
         game = Game(s_instructions = ss)
-        game.play(filter_check_naive=False, king_in_check_test_copy_apply_4=True)
+        game.play(filter_check_naive=False, filter_check_opt=True)
     
     if s_function == "baseline_tt":
         

--- a/basic_engine/tools/profile_test.py
+++ b/basic_engine/tools/profile_test.py
@@ -12,21 +12,21 @@ ss_long = '1. g1 e1 2. b1 d1 3. g2 e2 4. b3 d3 5. e2 d3 6. b6 d6 7. g5 e5 8. a2 
 def run_profiles():
     
     cmd =  """game = Game(s_instructions = ss); """
-    cmd += """game.play(king_in_check_on=False)"""
+    cmd += """game.play(filter_check_naive=False)"""
     cProfile.run( cmd, 'output_profile_1')
 
     cmd =  """game = Game(s_instructions = ss); """
-    cmd += """game.play(king_in_check_on=False """
+    cmd += """game.play(filter_check_naive=False """
     cmd += """          ,king_in_check_test_copy_apply=True """
     cmd += """          )"""
     cProfile.run( cmd, 'output_profile_2')
     
     cmd =  """game = Game(s_instructions = ss); """
-    cmd += """game.play(king_in_check_on=True)"""
+    cmd += """game.play(filter_check_naive=True)"""
     cProfile.run(cmd, 'output_profile_3')
 
     cmd =  """game = Game(s_instructions = ss); """
-    cmd += """game.play(king_in_check_on=False """
+    cmd += """game.play(filter_check_naive=False """
     cmd += """          ,king_in_check_optimal=True """
     cmd += """          )"""
     cProfile.run( cmd, 'output_profile_4')

--- a/basic_engine/tools/profile_test.py
+++ b/basic_engine/tools/profile_test.py
@@ -1,10 +1,12 @@
+import sys
 import cProfile
 import pstats
+sys.path.append('../')
 
-from main import Game
+from src.main import Game
 
-ss = "1. h7 f8 2. b1 c1 3. g5 e5 4. b2 c2 5. h6 f4 6. b3 c3 7. h5 h6 8. b4 c4 9. h6 h5 10. b5 c5"
-ss_long = '1. g1 e1 2. b1 d1 3. g2 e2 4. b3 d3 5. e2 d3 6. b6 d6 7. g5 e5 8. a2 c3 9. h4 d8 10. b7 c7 11. h6 c1 12. a1 c1 13. h1 f1 14. a6 c8 15. h7 f6 16. b2 d2 17. h3 g2 18. a5 a6 19. e1 d2 20. c8 d7 21. d8 c7 22. d7 e6 23. h5 h7 24. b8 c8 25. g3 e3 26. e6 b3 27. g7 e7 28. c3 e4 29. c7 b7 30. a6 a5 31. b7 c7 32. c1 c7 33. d2 c2 34. b4 d4 35. f6 e4 36. d6 e5 37. h2 f3 38. c8 d8 39. f1 d1 40. c7 c4 '
+ss = "1. g1 h3 2. a7 a6 3. e2 e4 4. b7 b6 5. f1 d3 6. c7 c6 7. e1 f1 8. d7 d6 9. f1 e1 10. e7 e6"
+
 
 #os.chdir("c:/users/wsutt/desktop/files/exercises/chess/basic_engine/")
 
@@ -17,7 +19,7 @@ def run_profiles():
 
     cmd =  """game = Game(s_instructions = ss); """
     cmd += """game.play(filter_check_naive=False """
-    cmd += """          ,king_in_check_test_copy_apply=True """
+    cmd += """          ,filter_check_test_copy_apply=True """
     cmd += """          )"""
     cProfile.run( cmd, 'output_profile_2')
     
@@ -27,7 +29,7 @@ def run_profiles():
 
     cmd =  """game = Game(s_instructions = ss); """
     cmd += """game.play(filter_check_naive=False """
-    cmd += """          ,king_in_check_optimal=True """
+    cmd += """          ,filter_check_test_copy_opt=True """
     cmd += """          )"""
     cProfile.run( cmd, 'output_profile_4')
 

--- a/basic_engine/tools/run.py
+++ b/basic_engine/tools/run.py
@@ -180,7 +180,7 @@ elif run_type == "randomplay2":
                      ,init_player = losing_player
                      ,test_exit_moves = 1 )
 
-        ret_moves = game2.play(king_in_check_on = True
+        ret_moves = game2.play(filter_check_naive = True
                                 ,king_in_check_test_copy_4 = False
                                 )
 

--- a/basic_engine/tools/run.py
+++ b/basic_engine/tools/run.py
@@ -181,7 +181,7 @@ elif run_type == "randomplay2":
                      ,test_exit_moves = 1 )
 
         ret_moves = game2.play(filter_check_naive = True
-                                ,king_in_check_test_copy_4 = False
+                                ,filter_check_opt = False
                                 )
 
         print 'Moves available: ', str(ret_moves['moves'])

--- a/notes.txt
+++ b/notes.txt
@@ -682,16 +682,55 @@ board should store edge cases:
 
             TODO
 
-                get into branch refactor-game
+                x get into branch refactor-game
 
-                put top of play into initialize()
+                x put top of play into initialize()
 
-                run initialize by default()
+                x run initialize by default()
+
+                x refactor main kwargs
+
+                refactor other kwargs
+
+                add check_for_check kwrarg to control 
+                calling is_king_in_check()
+
+                refactor function names and import names
+
+                refactor check_test_exit / check_test_exit_moves
+
+                refactor build_test_data
+                    rebench any tests
+
+                handle load() / save() to persist game
+
+                [break]
+
+                hello world on perf_test
+
+                send perf_tests data to data/perf_tests
+
+                build indexed samples of games to run in perf_tests
+
+                log perf_tests to sqlite
+
+                build some perf_test unit tests
+                    e.g test_strict_opt_time: opt < 3.5x baseline
+                        test_lax_opt_time: opt < 4.3x baseline
+                        we can keep running tests untill strict is reached
+
+                build GarryKasparov_clean.xpgn
+
+                add meta-data to pgn_to_xpgn
+                    current commit hash
+                    parse options requested
+
+                
 
             Grand Projects
 
                 Build an api at basic_engine level which allows apps to interface
-                with Game.
+                with Game. The M in MVC.
 
 
         HOWTOs


### PR DESCRIPTION
Eliminate the cruft that's accumulated in Game and play():

kwargs and function names for filter_check are now sensible.
note: these need to be applied to tests, profile_test, perf_test calls, and import calls in main.py
filter_check functions have docstrings which describe them, and re-ordered in TurnStage.

also play() was more modularized by putting board,pieces,player init into a separate function, Game.initialize()
note: this calls for some tests which do play() twice without re-init the Game object, to need to use game.reset_init_switch.

